### PR TITLE
fix: Docusaurus3 testing

### DIFF
--- a/docs/tutorials/tutorial-sketches-theta.md
+++ b/docs/tutorials/tutorial-sketches-theta.md
@@ -261,3 +261,5 @@ See the following topics for more information:
 ## Acknowledgments
 
 This tutorial is adapted from a [blog post](https://blog.hellmar-becker.de/2022/06/05/druid-data-cookbook-counting-unique-visitors-for-overlapping-segments/) by community member Hellmar Becker.
+
+---


### PR DESCRIPTION
Fix for Docusaurus 3:
- added horizontal line before footnote in **Approximations with Theta sketches** tutorial. Line was automatically added by `<sup>[^1]</sup>` in Docusaurus 2 but it no longer appears in Docusaurus 3.